### PR TITLE
Get entropy value from tuple, instead of toString

### DIFF
--- a/application/src/main/java/org/cardanofoundation/ledgersync/explorerconsumer/service/impl/ParamProposalServiceImpl.java
+++ b/application/src/main/java/org/cardanofoundation/ledgersync/explorerconsumer/service/impl/ParamProposalServiceImpl.java
@@ -76,13 +76,11 @@ public class ParamProposalServiceImpl implements ParamProposalService {
                     var treasuryGrowthRate = toDouble(protocolParamUpdate.getTreasuryGrowthRate());
                     var decentralisation = toDouble(protocolParamUpdate.getDecentralisationParam());
 
-//          var cborEntropy = protocolParamUpdate.getExtraEntropy(); //TODO refactor
-                    String entropy = protocolParamUpdate.getExtraEntropy();
-
-//          if (!CollectionUtils.isEmpty(cborEntropy) &&            //TODO refactor
-//              (int) cborEntropy.get(0) == BigInteger.ONE.intValue()) {
-//            entropy = cborEntropy.get(BigInteger.ONE.intValue()).toString();
-//          }
+                    var extraEntropyTuple = protocolParamUpdate.getExtraEntropy();
+                    String entropy = null;
+                    if (extraEntropyTuple != null) {
+                        entropy = extraEntropyTuple._2;
+                    }
 
                     var protocolMajor = protocolParamUpdate.getProtocolMajorVer();
                     var protocolMinor = protocolParamUpdate.getProtocolMinorVer();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [libraries]
-yaci-store-starter="com.bloxbean.cardano:yaci-store-spring-boot-starter:0.0.12-beta4.4-SNAPSHOT"
-yaci-store-utxo-starter="com.bloxbean.cardano:yaci-store-utxo-spring-boot-starter:0.0.12-beta4.4-SNAPSHOT"
-yaci-store-account-starter="com.bloxbean.cardano:yaci-store-account-spring-boot-starter:0.0.12-beta4.4-SNAPSHOT"
+yaci-store-starter="com.bloxbean.cardano:yaci-store-spring-boot-starter:0.0.12-beta4.5-SNAPSHOT"
+yaci-store-utxo-starter="com.bloxbean.cardano:yaci-store-utxo-spring-boot-starter:0.0.12-beta4.5-SNAPSHOT"
+yaci-store-account-starter="com.bloxbean.cardano:yaci-store-account-spring-boot-starter:0.0.12-beta4.5-SNAPSHOT"
 
 cardano-client-lib="com.bloxbean.cardano:cardano-client-lib:0.5.0-beta3"
 snakeyaml="org.yaml:snakeyaml:2.0"


### PR DESCRIPTION
To fix #14 

- Updated Yaci/Yaci Store version to get extraEntropy as Tuple instead of String

