### PR TITLE
fix: #33 fixed sql error during gin index creation

### DIFF
--- a/application/src/main/resources/db/migration/consumer/V1_1_21__create_missing_index.sql
+++ b/application/src/main/resources/db/migration/consumer/V1_1_21__create_missing_index.sql
@@ -4,7 +4,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS address_tx_balance_tx_id_idx ON address_tx_bal
 CREATE INDEX IF NOT EXISTS multi_asset_supply_idx ON multi_asset (supply);
 CREATE INDEX IF NOT EXISTS multi_asset_time_idx ON multi_asset ("time");
 
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA pg_catalog;
 CREATE INDEX IF NOT EXISTS name_view_gin_lower ON multi_asset USING gin (lower(name_view) gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS pool_name_gin_lower ON pool_offline_data USING gin (lower(pool_name) gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS asset_metadata_subject_idx ON asset_metadata (subject);


### PR DESCRIPTION
The PR modifies the migration file to create the pg_trgm extension with the pg_catalog schema, and  allow the gin index to be generated successfully in every schema.
