### PR TITLE
Fix: Redeemer  cbor parse error

### DIFF
--- a/application/src/main/java/org/cardanofoundation/ledgersync/explorerconsumer/aggregate/AggregatedTxOut.java
+++ b/application/src/main/java/org/cardanofoundation/ledgersync/explorerconsumer/aggregate/AggregatedTxOut.java
@@ -43,7 +43,7 @@ public class AggregatedTxOut {
         BigInteger nativeAmount = calculateOutSum(List.of(transactionOutput));
         Datum inlineDatum = null;
         if (transactionOutput.getInlineDatum() != null) {
-            inlineDatum = new Datum(transactionOutput.getInlineDatum(), ""); //TODO refactor convert to json
+            inlineDatum = new Datum(transactionOutput.getDatumHash(), transactionOutput.getInlineDatum(), ""); //TODO refactor convert to json
         }
 
         return AggregatedTxOut.builder()

--- a/application/src/main/java/org/cardanofoundation/ledgersync/explorerconsumer/util/RedeemerWrapper.java
+++ b/application/src/main/java/org/cardanofoundation/ledgersync/explorerconsumer/util/RedeemerWrapper.java
@@ -16,7 +16,7 @@ public class RedeemerWrapper {
         this.yaciRedeemer = yaciRedeemer;
         try {
             this.redeemer = com.bloxbean.cardano.client.plutus.spec.Redeemer.deserialize((Array) CborSerializationUtil.deserialize(HexUtil.decodeHexString(yaciRedeemer.getCbor())));
-        } catch (CborDeserializationException e) {
+        } catch (Exception e) {
             throw new IllegalStateException("Failed to deserialize redeemer", e);
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [libraries]
-yaci-store-starter="com.bloxbean.cardano:yaci-store-spring-boot-starter:0.0.13-beta2-11c3a6e-SNAPSHOT"
-yaci-store-remote-starter="com.bloxbean.cardano:yaci-store-remote-spring-boot-starter:0.0.13-beta2-11c3a6e-SNAPSHOT"
+yaci-store-starter="com.bloxbean.cardano:yaci-store-spring-boot-starter:0.0.13-beta2-ac12d37-SNAPSHOT"
+yaci-store-remote-starter="com.bloxbean.cardano:yaci-store-remote-spring-boot-starter:0.0.13-beta2-ac12d37-SNAPSHOT"
 
 cardano-client-lib="com.bloxbean.cardano:cardano-client-lib:0.5.0"
 snakeyaml="org.yaml:snakeyaml:2.0"


### PR DESCRIPTION
#70 

- Fix Yaci to send correct cbor by directly getting redeemer bytes from block body instead of deserialization and serialization (https://github.com/bloxbean/yaci/pull/38)
- Added hash field to Datum
- Bump yaci-store version to include yaci related changes 