### PR TITLE
fix: #96 add condition to verify if network is testnet

### DIFF
--- a/components/common/src/main/java/org/cardanofoundation/ledgersync/common/common/constant/Constant.java
+++ b/components/common/src/main/java/org/cardanofoundation/ledgersync/common/common/constant/Constant.java
@@ -26,8 +26,6 @@ public final class Constant {
   public static final int SLOT_LEADER_LENGTH = 28;
 
   public static boolean isTestnet(int networkMagic) {
-    return networkMagic == TESTNET
-        || networkMagic == PREPROD_TESTNET
-        || networkMagic == PREVIEW_TESTNET;
+    return networkMagic != MAINNET;
   }
 }


### PR DESCRIPTION
Root cause: misssing condition to verify a network is testnet -> reward account hex calculation is wrong when certificate is pool registraion. (BlockAggregatorServiceImpl.java)
```
                // Reward account
                // Workaround for bug https://github.com/input-output-hk/cardano-db-sync/issues/546
                String rewardAccountHex = poolRegistration.getPoolParams().getRewardAccount();
                byte[] rewardAccountBytes = HexUtil.decodeHexString(rewardAccountHex);
                int networkId = Constant.isTestnet(network) ? 0 : 1;
                byte header = rewardAccountBytes[0];
                if (((header & 0xff) & networkId) == 0) {
                    rewardAccountBytes[0] = (byte) ((header & ~1) | networkId);
                }
                blockDataService.saveFirstAppearedTxHashForStakeAddress(
                        HexUtil.encodeHexString(rewardAccountBytes), txHash);
```