### PR TITLE
Allow custom db configuration from secrets or parameters

### DIFF
--- a/deploy/cf-ledger-sync/templates/cardano-node-statefulset.yaml
+++ b/deploy/cf-ledger-sync/templates/cardano-node-statefulset.yaml
@@ -31,6 +31,9 @@ spec:
       containers:
         - name: cardano-node
           image: "{{ .image.repository }}:{{ .image.tag }}"
+          {{- if .sleep }}
+          command: ["bash", "-c", "sleep infinity"]
+          {{- end }}
           env:
             - name: RESTORE_SNAPSHOT
               value: "{{ .mithrilRestore | default true }}"

--- a/deploy/cf-ledger-sync/templates/cardano-node-statefulset.yaml
+++ b/deploy/cf-ledger-sync/templates/cardano-node-statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: cardano-node
           image: "{{ .image.repository }}:{{ .image.tag }}"
-          {{- if .sleep }}
+          {{- if .sleep | default false }}
           command: ["bash", "-c", "sleep infinity"]
           {{- end }}
           env:

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             {{- end }}
             
             ## Postgres
-            {{- with .Value.aggregation.postgres }}
+            {{- with .Values.aggregation.postgres }}
             - name: POSTGRES_HOST
               {{- if .host }}
               value: {{ .host }}

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -123,6 +123,8 @@ spec:
               value: "120"
             - name: STORE_ADMIN_AUTORECOVERYENABLED
               value: "true"
+            - name: STORE_EXECUTOR_BLOCKPROCESSINGTHREADS
+              value: {{ .Values.aggregation.store.executor.block_processing_threads | default 15 | quote }}
             - name: STORE_EXECUTOR_USEVIRTUALTHREADFORBATCHPROCESSING
               value: {{ .Values.aggregation.store.executor.use_virtual_thread_for_batch_processing | default "false" | quote }}
 

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -58,35 +58,37 @@ spec:
             {{- end }}
             
             ## Postgres
+            {{- with .Value.indexer.aggregation }}
             - name: POSTGRES_HOST
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secrets
-                  key: POSTGRES_HOST
+                  name: {{ .secretName }}
+                  key: {{ .hostKey }}
             - name: POSTGRES_PORT
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secrets
-                  key: POSTGRES_PORT
+                  name: {{ .secretName }}
+                  key: {{ .portKey }}
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secrets
-                  key: POSTGRES_DB
-            - name: SCHEMA
+                  name: {{ .secretName }}
+                  key: {{ .dbKey }}
+            - name: POSTGRES_SCHEMA
               value: {{ .Values.dbSchema | default "public" }}
             - name: SPRING_DATASOURCE_URL
-              value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema=$(SCHEMA)
+              value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema=$(POSTGRES_SCHEMA)
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secrets
-                  key: POSTGRES_USER
+                  name: {{ .secretName }}
+                  key: {{ .userKey }}
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secrets
-                  key: POSTGRES_PASSWORD
+                  name: {{ .secretName }}
+                  key: {{ .passwordKey }}
+            {{- end }}
 
             - name: STORE_ACCOUNT_HISTORYCLEANUPENABLED
               value: {{ .Values.aggregation.store.account.history_cleanup_enabled | quote }}

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -123,6 +123,8 @@ spec:
               value: "120"
             - name: STORE_ADMIN_AUTORECOVERYENABLED
               value: "true"
+            - name: STORE_EXECUTOR_USEVIRTUALTHREADFORBATCHPROCESSING
+              value: {{ .Values.aggregation.store.executor.use_virtual_thread_for_batch_processing | default "false" }}
 
           resources:
             {{- toYaml .Values.aggregation.resources | nindent 12 }}

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "cf-ledger-sync-aggregation.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.aggregation.replicaCount }}
   selector:
     matchLabels:
       {{- include "cf-ledger-sync-aggregation.selectorLabels" . | nindent 6 }}

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -86,10 +86,10 @@ spec:
                   name: {{ .secretName }}
                   key: {{ .dbKey }}
               {{- end }}
-            - name: POSTGRES_SCHEMA
+            - name: SCHEMA
               value: {{ .dbSchema | default "aggregation" }}
             - name: SPRING_DATASOURCE_URL
-              value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema=$(POSTGRES_SCHEMA)
+              value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema=$(SCHEMA)
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -70,7 +70,7 @@ spec:
               {{- end }}
             - name: POSTGRES_PORT
               {{- if .port }}
-              value: {{ .port }}
+              value: {{ .port | quote }}
               {{- else }}
               valueFrom:
                 secretKeyRef:

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: STORE_CARDANO_PROTOCOL_MAGIC
               value: {{ .Values.storeCardanoProtocolMagic | default "1" | quote }}
             {{- end }}
-            
+
             ## Postgres
             {{- with .Values.aggregation.postgres }}
             - name: POSTGRES_HOST
@@ -102,8 +102,28 @@ spec:
                   key: {{ .passwordKey }}
             {{- end }}
 
+            - name: HEALTH_CHECK_ENABLED
+              value: "true"
+            - name: EVENT_TIME_THRESHOLD_IN_SECOND
+              value: "600"
+            - name: BLOCK_TIME_CHECK_ENABLED
+              value: "true"
+            - name: BLOCK_TIME_THRESHOLD_IN_SECOND
+              value: "180"
+
             - name: STORE_ACCOUNT_HISTORYCLEANUPENABLED
               value: {{ .Values.aggregation.store.account.history_cleanup_enabled | quote }}
+            - name: STORE_ACCOUNT_INITIALBALANCESNAPSHOTBLOCK
+              value: "0"
+            - name: STORE_ACCOUNT_BALANCECALCJOBBATCHSIZE
+              value: "500"
+            - name: STORE_ACCOUNT_BALANCECALCJOBPARTITIONSIZE
+              value: "5"
+            - name: STORE_ADMIN_HEALTHCHECKINTERVAL
+              value: "120"
+            - name: STORE_ADMIN_AUTORECOVERYENABLED
+              value: "true"
+
           resources:
             {{- toYaml .Values.aggregation.resources | nindent 12 }}
 {{ end }}

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -128,4 +128,6 @@ spec:
 
           resources:
             {{- toYaml .Values.aggregation.resources | nindent 12 }}
+  strategy:
+    type: Recreate
 {{ end }}

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -127,6 +127,8 @@ spec:
               value: {{ .Values.aggregation.store.executor.block_processing_threads | default 15 | quote }}
             - name: STORE_EXECUTOR_USEVIRTUALTHREADFORBATCHPROCESSING
               value: {{ .Values.aggregation.store.executor.use_virtual_thread_for_batch_processing | default "false" | quote }}
+            - name: STORE_EXECUTOR_ENABLEPARALLELPROCESSING
+              value: {{ .Values.aggregation.store.executor.enable_parallel_processing | default "true" | quote }}
 
           resources:
             {{- toYaml .Values.aggregation.resources | nindent 12 }}

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -58,24 +58,36 @@ spec:
             {{- end }}
             
             ## Postgres
-            {{- with .Value.indexer.aggregation }}
+            {{- with .Value.aggregation.postgres }}
             - name: POSTGRES_HOST
+              {{- if .host }}
+              value: {{ .host }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .secretName }}
                   key: {{ .hostKey }}
+              {{- end }}
             - name: POSTGRES_PORT
+              {{- if .port }}
+              value: {{ .port }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .secretName }}
                   key: {{ .portKey }}
+              {{- end }}
             - name: POSTGRES_DB
+              {{- if .db }}
+              value: {{ .db }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .secretName }}
                   key: {{ .dbKey }}
+              {{- end }}
             - name: POSTGRES_SCHEMA
-              value: {{ .Values.dbSchema | default "public" }}
+              value: {{ .dbSchema | default "aggregation" }}
             - name: SPRING_DATASOURCE_URL
               value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema=$(POSTGRES_SCHEMA)
             - name: SPRING_DATASOURCE_USERNAME

--- a/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-aggregation-deployment.yaml
@@ -124,7 +124,7 @@ spec:
             - name: STORE_ADMIN_AUTORECOVERYENABLED
               value: "true"
             - name: STORE_EXECUTOR_USEVIRTUALTHREADFORBATCHPROCESSING
-              value: {{ .Values.aggregation.store.executor.use_virtual_thread_for_batch_processing | default "false" }}
+              value: {{ .Values.aggregation.store.executor.use_virtual_thread_for_batch_processing | default "false" | quote }}
 
           resources:
             {{- toYaml .Values.aggregation.resources | nindent 12 }}

--- a/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
@@ -145,3 +145,5 @@ spec:
             timeoutSeconds: 1
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+  strategy:
+    type: Recreate

--- a/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
@@ -77,7 +77,7 @@ spec:
               value: {{ .Values.blocks.commitThreshold | default "3000" | quote }}
 
             ## Postgres
-            {{- with .Value.indexer.postgres }}
+            {{- with .Values.indexer.postgres }}
             - name: POSTGRES_HOST
               {{- if .host }}
               value: {{ .host }}

--- a/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
@@ -89,7 +89,7 @@ spec:
               {{- end }}
             - name: POSTGRES_PORT
               {{- if .port }}
-              value: {{ .port }}
+              value: {{ .port | quote }}
               {{- else }}
               valueFrom:
                 secretKeyRef:

--- a/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
@@ -77,35 +77,37 @@ spec:
               value: {{ .Values.blocks.commitThreshold | default "3000" | quote }}
 
             ## Postgres
+            {{- with .Value.indexer.postgres }}
             - name: POSTGRES_HOST
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secrets
-                  key: POSTGRES_HOST
+                  name: {{ .secretName }}
+                  key: {{ .hostKey }}
             - name: POSTGRES_PORT
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secrets
-                  key: POSTGRES_PORT
+                  name: {{ .secretName }}
+                  key: {{ .portKey }}
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secrets
-                  key: POSTGRES_DB
-            - name: SCHEMA
+                  name: {{ .secretName }}
+                  key: {{ .dbKey }}
+            - name: POSTGRES_SCHEMA
               value: {{ .Values.dbSchema | default "public" }}
             - name: SPRING_DATASOURCE_URL
-              value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema=$(SCHEMA)
+              value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema=$(POSTGRES_SCHEMA)
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secrets
-                  key: POSTGRES_USER
+                  name: {{ .secretName }}
+                  key: {{ .userKey }}
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secrets
-                  key: POSTGRES_PASSWORD
+                  name: {{ .secretName }}
+                  key: {{ .passwordKey }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
@@ -79,22 +79,34 @@ spec:
             ## Postgres
             {{- with .Value.indexer.postgres }}
             - name: POSTGRES_HOST
+              {{- if .host }}
+              value: {{ .host }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .secretName }}
                   key: {{ .hostKey }}
+              {{- end }}
             - name: POSTGRES_PORT
+              {{- if .port }}
+              value: {{ .port }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .secretName }}
                   key: {{ .portKey }}
+              {{- end }}
             - name: POSTGRES_DB
+              {{- if .db }}
+              value: {{ .db }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .secretName }}
                   key: {{ .dbKey }}
+              {{- end }}
             - name: POSTGRES_SCHEMA
-              value: {{ .Values.dbSchema | default "public" }}
+              value: {{ .dbSchema | default "aggregation" }}
             - name: SPRING_DATASOURCE_URL
               value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema=$(POSTGRES_SCHEMA)
             - name: SPRING_DATASOURCE_USERNAME

--- a/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "cf-ledger-sync.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.indexer.replicaCount }}
   strategy:
     type: Recreate
   selector:

--- a/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
+++ b/deploy/cf-ledger-sync/templates/ledger-sync-deployment.yaml
@@ -105,10 +105,10 @@ spec:
                   name: {{ .secretName }}
                   key: {{ .dbKey }}
               {{- end }}
-            - name: POSTGRES_SCHEMA
+            - name: SCHEMA
               value: {{ .dbSchema | default "aggregation" }}
             - name: SPRING_DATASOURCE_URL
-              value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema=$(POSTGRES_SCHEMA)
+              value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema=$(SCHEMA)
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/deploy/cf-ledger-sync/values-mainnet.yaml
+++ b/deploy/cf-ledger-sync/values-mainnet.yaml
@@ -1,3 +1,11 @@
+indexer:
+  postgres:
+    dbSchema: mainnet
+
+aggregation:
+  postgres:
+    dbSchema: aggregation-mainnet
+
 dbSchema: mainnet
 network: mainnet
 localCardanoNode:

--- a/deploy/cf-ledger-sync/values-mainnet.yaml
+++ b/deploy/cf-ledger-sync/values-mainnet.yaml
@@ -4,7 +4,7 @@ indexer:
 
 aggregation:
   postgres:
-    dbSchema: aggregation-mainnet
+    dbSchema: mainnet_aggregation
 
 dbSchema: mainnet
 network: mainnet

--- a/deploy/cf-ledger-sync/values-preprod.yaml
+++ b/deploy/cf-ledger-sync/values-preprod.yaml
@@ -1,3 +1,11 @@
+indexer:
+  postgres:
+    dbSchema: preprod
+
+aggregation:
+  postgres:
+    dbSchema: aggregation-preprod
+
 domain: dev-sranjan.cf-explorer-preprod.eu-west-1.metadata.dev.cf-deployments.org
 dbSchema: preprod
 localCardanoNode:

--- a/deploy/cf-ledger-sync/values-preprod.yaml
+++ b/deploy/cf-ledger-sync/values-preprod.yaml
@@ -4,7 +4,7 @@ indexer:
 
 aggregation:
   postgres:
-    dbSchema: aggregation-preprod
+    dbSchema: preprod_aggregation
 
 domain: dev-sranjan.cf-explorer-preprod.eu-west-1.metadata.dev.cf-deployments.org
 dbSchema: preprod

--- a/deploy/cf-ledger-sync/values-preview.yaml
+++ b/deploy/cf-ledger-sync/values-preview.yaml
@@ -12,7 +12,7 @@ indexer:
 
 aggregation:
   postgres:
-    dbSchema: aggregation-preview
+    dbSchema: preview_aggregation
   store:
     executor:
       use_virtual_thread_for_batch_processing: "true"

--- a/deploy/cf-ledger-sync/values-preview.yaml
+++ b/deploy/cf-ledger-sync/values-preview.yaml
@@ -5,3 +5,8 @@ localCardanoNode:
 storeCardanoHost: preview-node.play.dev.cardano.org
 storeCardanoPort: 3001
 storeCardanoProtocolMagic: 2
+
+aggregation:
+  store:
+    executor:
+      use_virtual_thread_for_batch_processing: "true"

--- a/deploy/cf-ledger-sync/values-preview.yaml
+++ b/deploy/cf-ledger-sync/values-preview.yaml
@@ -6,7 +6,13 @@ storeCardanoHost: preview-node.play.dev.cardano.org
 storeCardanoPort: 3001
 storeCardanoProtocolMagic: 2
 
+indexer:
+  postgres:
+    dbSchema: preview
+
 aggregation:
+  postgres:
+    dbSchema: aggregation-preview
   store:
     executor:
       use_virtual_thread_for_batch_processing: "true"

--- a/deploy/cf-ledger-sync/values-sanchonet.yaml
+++ b/deploy/cf-ledger-sync/values-sanchonet.yaml
@@ -1,3 +1,11 @@
+indexer:
+  postgres:
+    dbSchema: sanchonet
+
+aggregation:
+  postgres:
+    dbSchema: aggregation-sanchonet
+
 dbSchema: sanchonet
 network: sanchonet
 localCardanoNode:

--- a/deploy/cf-ledger-sync/values-sanchonet.yaml
+++ b/deploy/cf-ledger-sync/values-sanchonet.yaml
@@ -4,7 +4,7 @@ indexer:
 
 aggregation:
   postgres:
-    dbSchema: aggregation-sanchonet
+    dbSchema: sanchonet_aggregation
 
 dbSchema: sanchonet
 network: sanchonet

--- a/deploy/cf-ledger-sync/values.yaml
+++ b/deploy/cf-ledger-sync/values.yaml
@@ -82,4 +82,6 @@ aggregation:
   store:
     account:
       history_cleanup_enabled: "true"
+    executor:
+      use_virtual_thread_for_batch_processing: "false"
   resources: {}

--- a/deploy/cf-ledger-sync/values.yaml
+++ b/deploy/cf-ledger-sync/values.yaml
@@ -51,13 +51,60 @@ blocks:
 
 dbSchema: public
 
+
+  - name: POSTGRES_HOST
+    valueFrom:
+      secretKeyRef:
+        name: postgres-secrets
+        key: POSTGRES_HOST
+  - name: POSTGRES_PORT
+    valueFrom:
+      secretKeyRef:
+        name: postgres-secrets
+        key: POSTGRES_PORT
+  - name: POSTGRES_DB
+    valueFrom:
+      secretKeyRef:
+        name: postgres-secrets
+        key: POSTGRES_DB
+  - name: SPRING_DATASOURCE_URL
+    value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema={{ .Values.dbSchema | default "public" }}
+  - name: SPRING_DATASOURCE_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: postgres-secrets
+        key: POSTGRES_USER
+  - name: SPRING_DATASOURCE_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: postgres-secrets
+        key: POSTGRES_PASSWORD
+
+indexer:
+  postgres:
+    dbSchema: public
+    secretName: postgres-secrets
+    hostKey: POSTGRES_HOST
+    portKey: POSTGRES_PORT
+    dbKey: POSTGRES_DB
+    userKey: POSTGRES_USER
+    passwordKey: POSTGRES_PASSWORD
+
+
 aggregation:
   enabled: false
   image:
     repository: cardanofoundation/cf-ledger-sync-aggregation
     tag: "7b05530"
     pullPolicy: Always
-  dbSchema: public
+  postgres:
+    dbSchema: aggregation
+    secretName: postgres-secrets
+    hostKey: POSTGRES_HOST
+    portKey: POSTGRES_PORT
+    dbKey: POSTGRES_DB
+    userKey: POSTGRES_USER
+    passwordKey: POSTGRES_PASSWORD
   store:
     account:
       history_cleanup_enabled: "true"

--- a/deploy/cf-ledger-sync/values.yaml
+++ b/deploy/cf-ledger-sync/values.yaml
@@ -51,35 +51,6 @@ blocks:
 
 dbSchema: public
 
-
-  - name: POSTGRES_HOST
-    valueFrom:
-      secretKeyRef:
-        name: postgres-secrets
-        key: POSTGRES_HOST
-  - name: POSTGRES_PORT
-    valueFrom:
-      secretKeyRef:
-        name: postgres-secrets
-        key: POSTGRES_PORT
-  - name: POSTGRES_DB
-    valueFrom:
-      secretKeyRef:
-        name: postgres-secrets
-        key: POSTGRES_DB
-  - name: SPRING_DATASOURCE_URL
-    value: jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?currentSchema={{ .Values.dbSchema | default "public" }}
-  - name: SPRING_DATASOURCE_USERNAME
-    valueFrom:
-      secretKeyRef:
-        name: postgres-secrets
-        key: POSTGRES_USER
-  - name: SPRING_DATASOURCE_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: postgres-secrets
-        key: POSTGRES_PASSWORD
-
 indexer:
   postgres:
     dbSchema: public

--- a/deploy/cf-ledger-sync/values.yaml
+++ b/deploy/cf-ledger-sync/values.yaml
@@ -52,6 +52,8 @@ blocks:
 dbSchema: public
 
 indexer:
+  enabled: true
+  replicaCount: 1
   postgres:
     dbSchema: public
     secretName: postgres-secrets
@@ -64,6 +66,7 @@ indexer:
 
 aggregation:
   enabled: false
+  replicaCount: 1
   image:
     repository: cardanofoundation/cf-ledger-sync-aggregation
     tag: "7b05530"

--- a/deploy/cf-ledger-sync/values.yaml
+++ b/deploy/cf-ledger-sync/values.yaml
@@ -55,7 +55,7 @@ indexer:
   enabled: true
   replicaCount: 1
   postgres:
-    dbSchema: public
+#    dbSchema: public
     secretName: postgres-secrets
     hostKey: POSTGRES_HOST
     portKey: POSTGRES_PORT
@@ -72,7 +72,7 @@ aggregation:
     tag: "7b05530"
     pullPolicy: Always
   postgres:
-    dbSchema: aggregation
+#    dbSchema: aggregation
     secretName: postgres-secrets
     hostKey: POSTGRES_HOST
     portKey: POSTGRES_PORT

--- a/deploy/cf-ledger-sync/values.yaml
+++ b/deploy/cf-ledger-sync/values.yaml
@@ -83,5 +83,10 @@ aggregation:
     account:
       history_cleanup_enabled: "true"
     executor:
-      use_virtual_thread_for_batch_processing: "false"
+      # Whether to use parallel processing. This greatly reduces DB computation requirements
+      enable_parallel_processing: "true"
+      # Whether to use virtual threads. True recommended for multi-CPU architecture, false for VMs
+      use_virtual_thread_for_batch_processing: "true"
+      # Number of concurrent batching threads
+      block_processing_threads: 15
   resources: {}

--- a/deploy/cf-ledger-sync/values.yaml
+++ b/deploy/cf-ledger-sync/values.yaml
@@ -68,7 +68,7 @@ aggregation:
   enabled: false
   replicaCount: 1
   image:
-    repository: cardanofoundation/cf-ledger-sync-aggregation
+    repository: pro.registry.gitlab.metadata.dev.cf-deployments.org/base-infrastructure/docker-registry/cf-ledger-sync-aggregation
     tag: "7b05530"
     pullPolicy: Always
   postgres:


### PR DESCRIPTION
This PR introduces changes to LSv2 and Node charts

# LSv2

Extended db configuration so to allow any combination of properties or secret injected values.

Some properties are not sensitive, like `host` in this case, user can specify either the vanilla hostname or the couple secret name + secret key. Plain values, like `host` in this case, have priority.

This allows LS to work w/ 
* vanilla psql helm chart
* aws rds managed services
* zalando operator (that creates secrets on our behalf)

## Example 1

In this case the `POSTGRES_HOST` env var can be either a plain text property set as part of the helm chart values via the `host` property, or kept null and set through the secretName/hostKey.

the `SPRING_DATASOURCE_USERNAME` is instead considered sensitive and must be set as secretName/userKey.

```yaml
        - name: POSTGRES_HOST
          {{- if .host }}
          value: {{ .host }}
          {{- else }}
          valueFrom:
            secretKeyRef:
              name: postgres-secrets
              key: POSTGRES_HOST
              name: {{ .secretName }}
              key: {{ .hostKey }}
          {{- end }}
            - name: SPRING_DATASOURCE_USERNAME
              valueFrom:
                secretKeyRef:
                  name: postgres-secrets
                  key: POSTGRES_USER
                  name: {{ .secretName }}
                  key: {{ .userKey }}
```

# Node

Added `sleep` flag to allow the container to restart with `sleep infinity` and allow for manual maintenance. This was used to manually fix mithril breaking change.
